### PR TITLE
Maintenance/comscore

### DIFF
--- a/comscore/README.md
+++ b/comscore/README.md
@@ -20,36 +20,37 @@ Create the connector by providing the `THEOplayer` instance, a ComscoreConfigura
 import { useComscore } from '@theoplayer/react-native-analytics-comscore';
 
 export const comscoreMetadata: ComscoreMetadata = {
-  mediaType: ComscoreMediaType.longFormOnDemand,
-  uniqueId: "testuniqueId",
-  length: 634.566,
-  stationTitle: "THEOTV",
-  programTitle: "Big Buck Bunny",
-  episodeTitle: "Intro",
-  genreName: "Animation",
-  classifyAsAudioStream: false,
-  customLabels: {
-    "testcustomlabel": "testcustomvalue"
-  }
+    mediaType: ComscoreMediaType.longFormOnDemand,
+    uniqueId: 'testuniqueId',
+    length: 634.566,
+    stationTitle: 'THEOTV',
+    programTitle: 'Big Buck Bunny',
+    episodeTitle: 'Intro',
+    genreName: 'Animation',
+    classifyAsAudioStream: false,
+    customLabels: {
+        testcustomlabel: 'testcustomvalue'
+    }
 };
 
 const comscoreConfig: ComscoreConfiguration = {
-    publisherId: "<your publisher id (aka c2 id)",
-    applicationName: "<your app name>",
+    publisherId: '<your publisher id (aka c2 id)',
+    applicationName: '<your app name>',
     userConsent: ComscoreUserConsent.granted,
-    debug: true,
-  };
+    usagePropertiesAutoUpdateMode: ComscoreUsagePropertiesAutoUpdateMode.foregroundOnly,
+    debug: true
+};
 
 const App = () => {
-  const [comscore, initComscore] = useComscore(COMSCORE_METADATA, comscoreConfig);
+    const [comscore, initComscore] = useComscore(COMSCORE_METADATA, comscoreConfig);
 
-  const onPlayerReady = (player: THEOplayer) => {
-    // Initialize Comscore connector
-    initComscore(player);
-  }
+    const onPlayerReady = (player: THEOplayer) => {
+        // Initialize Comscore connector
+        initComscore(player);
+    };
 
-  return (<THEOplayerView config={playerConfig} onPlayerReady={onPlayerReady}/>);
-}
+    return <THEOplayerView config={playerConfig} onPlayerReady={onPlayerReady} />;
+};
 ```
 
 ### Passing metadata dynamically
@@ -58,19 +59,19 @@ The connector allows passing or updating the current asset's metadata at any tim
 
 ```typescript
 const onUpdateMetadata = () => {
-  comscore.current.update({
-      mediaType: ComscoreMediaType.longFormOnDemand,
-      uniqueId: 'testuniqueId',
-      length: 634.566,
-      stationTitle: 'THEOTV',
-      programTitle: 'Big Buck Bunny',
-      episodeTitle: 'Intro',
-      genreName: 'Animation',
-      classifyAsAudioStream: false,
-      customLabels: {
-          testcustomlabel: 'testcustomvalue'
-      }
-  });
+    comscore.current.update({
+        mediaType: ComscoreMediaType.longFormOnDemand,
+        uniqueId: 'testuniqueId',
+        length: 634.566,
+        stationTitle: 'THEOTV',
+        programTitle: 'Big Buck Bunny',
+        episodeTitle: 'Intro',
+        genreName: 'Animation',
+        classifyAsAudioStream: false,
+        customLabels: {
+            testcustomlabel: 'testcustomvalue'
+        }
+    });
 };
 ```
 

--- a/comscore/android/src/main/java/com/theoplayercomscore/ReactTHEOplayerComscoreModule.kt
+++ b/comscore/android/src/main/java/com/theoplayercomscore/ReactTHEOplayerComscoreModule.kt
@@ -1,6 +1,7 @@
 package com.theoplayercomscore
 
 import android.util.Log
+import com.comscore.UsagePropertiesAutoUpdateMode
 import com.facebook.react.bridge.*
 import com.theoplayer.ReactTHEOplayerView
 import com.theoplayer.util.ViewResolver
@@ -72,11 +73,21 @@ class ReactTHEOplayerComscoreModule(context: ReactApplicationContext) :
     return ComscoreConfiguration(
       config.getString("publisherId") ?: "",
       config.getString("applicationName") ?: "",
+      mapUsagePropertiesAutoUpdateMode(config.getString("usagePropertiesAutoUpdateMode") ?: "foregroundOnly"),
       config.getString("userConsent") ?: "0",
       secureTransmission = false, // TODO: bring in line with other platforms
       childDirected = false, // TODO: bring in line with other platforms
       debug = config.getBoolean("debug")
     )
+  }
+
+  private fun mapUsagePropertiesAutoUpdateMode(usagePropertiesAutoUpdateMode: String): Int {
+    return when(usagePropertiesAutoUpdateMode) {
+      "foregroundOnly" -> UsagePropertiesAutoUpdateMode.FOREGROUND_ONLY
+      "foregroundAndBackground" -> UsagePropertiesAutoUpdateMode.FOREGROUND_AND_BACKGROUND
+      "disabled" -> UsagePropertiesAutoUpdateMode.DISABLED
+      else -> UsagePropertiesAutoUpdateMode.FOREGROUND_ONLY
+    }
   }
 
   private fun mapDate(date: ReadableMap?): ComscoreDate? {

--- a/comscore/android/src/main/java/com/theoplayercomscore/integration/ComscoreAdapter.kt
+++ b/comscore/android/src/main/java/com/theoplayercomscore/integration/ComscoreAdapter.kt
@@ -284,6 +284,9 @@ class ComscoreAdapter(
         }
         comScoreState = ComscoreState.VIDEO
         setContentMetadata()
+        if (BuildConfig.DEBUG) {
+          Log.i(TAG, "DEBUG: notifyPlay")
+        }
         streamingAnalytics.notifyPlay()
       }
       ComscoreState.VIDEO -> {}

--- a/comscore/android/src/main/java/com/theoplayercomscore/integration/ComscoreAdapter.kt
+++ b/comscore/android/src/main/java/com/theoplayercomscore/integration/ComscoreAdapter.kt
@@ -374,6 +374,12 @@ class ComscoreAdapter(
         Log.i(TAG, "DEBUG: notifyBufferStop")
       }
       streamingAnalytics.notifyBufferStop()
+      if (comScoreState == ComscoreState.VIDEO) {
+        if (BuildConfig.DEBUG) {
+          Log.i(TAG, "DEBUG: notifyPlay")
+        }
+        streamingAnalytics.notifyPlay()
+      }
     }
     if (inAd) {
       transitionToAdvertisement() // will set ad metadata and notify play if not done already

--- a/comscore/android/src/main/java/com/theoplayercomscore/integration/ComscoreAnalytics.kt
+++ b/comscore/android/src/main/java/com/theoplayercomscore/integration/ComscoreAnalytics.kt
@@ -34,7 +34,7 @@ class ComscoreAnalytics {
       addClient(PublisherConfiguration.Builder()
         .publisherId(configuration.publisherId)
         .secureTransmission(configuration.secureTransmission).apply {
-          if (configuration.userConsent === "1" || configuration.userConsent === "0") {
+          if (configuration.userConsent == "1" || configuration.userConsent == "0") {
             persistentLabels(hashMapOf("cs_ucfr" to configuration.userConsent))
           }
         }

--- a/comscore/android/src/main/java/com/theoplayercomscore/integration/ComscoreAnalytics.kt
+++ b/comscore/android/src/main/java/com/theoplayercomscore/integration/ComscoreAnalytics.kt
@@ -40,7 +40,7 @@ class ComscoreAnalytics {
         }
         .build()
       )
-      setUsagePropertiesAutoUpdateMode(UsagePropertiesAutoUpdateMode.FOREGROUND_AND_BACKGROUND)
+      setUsagePropertiesAutoUpdateMode(configuration.usagePropertiesAutoUpdateMode)
       setApplicationName(configuration.applicationName)
       if (configuration.childDirected) {
         enableChildDirectedApplicationMode()

--- a/comscore/android/src/main/java/com/theoplayercomscore/integration/ComscoreConfiguration.kt
+++ b/comscore/android/src/main/java/com/theoplayercomscore/integration/ComscoreConfiguration.kt
@@ -3,6 +3,7 @@ package com.theoplayercomscore.integration
 data class ComscoreConfiguration(
   val publisherId: String,
   val applicationName: String,
+  val usagePropertiesAutoUpdateMode: Int,
   val userConsent: String,
   val secureTransmission: Boolean,
   val childDirected: Boolean,

--- a/comscore/example/src/App.tsx
+++ b/comscore/example/src/App.tsx
@@ -21,7 +21,7 @@ import {
   UiContainer
 } from "@theoplayer/react-native-ui";
 import { useComscore } from '@theoplayer/react-native-analytics-comscore';
-import { ComscoreConfiguration, ComscoreMetadata, ComscoreMediaType, ComscoreUserConsent } from '@theoplayer/react-native-analytics-comscore';
+import { ComscoreConfiguration, ComscoreMetadata, ComscoreMediaType, ComscoreUserConsent, ComscoreUsagePropertiesAutoUpdateMode } from '@theoplayer/react-native-analytics-comscore';
 import { SourceMenuButton, SOURCES } from "./custom/SourceMenuButton";
 
 if (Platform.OS === 'web') {
@@ -45,12 +45,16 @@ const comscoreMetadata: ComscoreMetadata = {
   classifyAsAudioStream: false,
   customLabels: {
     "testcustomlabel": "testcustomvalue"
-  }
+  },
+  c3: "c3value",
+  c4: "c4value",
+  c6: "c6value"
 };
 
 const comscoreConfig: ComscoreConfiguration = {
   publisherId: "<publisherId>", // Can be a test or production key.
   applicationName: "ReactNativeTHEOplayer",
+  usagePropertiesAutoUpdateMode: ComscoreUsagePropertiesAutoUpdateMode.foregroundAndBackground,
   userConsent: ComscoreUserConsent.granted,
   debug: true,
 };

--- a/comscore/src/api/ComscoreConfiguration.ts
+++ b/comscore/src/api/ComscoreConfiguration.ts
@@ -4,10 +4,23 @@ export enum ComscoreUserConsent {
     unknown = "-1"
 }
 
+export enum ComscoreUsagePropertiesAutoUpdateMode {
+    foregroundOnly = "foregroundOnly",
+    foregroundAndBackground = "foregroundAndBackground",
+    disabled = "disabled"
+}
+
 export interface ComscoreConfiguration {
+    /**
+     * Also known as the c2 value
+     */
     publisherId: string;
     applicationName: string;
     userConsent: ComscoreUserConsent;
+    /**
+     * Defaults to foregroundOnly if none is specified. If your app has some background experience, use foregroundAndBackground.
+     */
+    usagePropertiesAutoUpdateMode?: ComscoreUsagePropertiesAutoUpdateMode;
     debug?: boolean;
 }
 

--- a/comscore/src/index.ts
+++ b/comscore/src/index.ts
@@ -1,6 +1,6 @@
 export { ComscoreConnector } from './api/ComscoreConnector';
 export type { ComscoreConfiguration } from './api/ComscoreConfiguration';
-export { ComscoreUserConsent } from './api/ComscoreConfiguration';
+export { ComscoreUserConsent, ComscoreUsagePropertiesAutoUpdateMode } from './api/ComscoreConfiguration';
 export {
     ComscoreMediaType,
     ComscoreFeedType,

--- a/comscore/src/internal/ComscoreConnectorAdapter.web.ts
+++ b/comscore/src/internal/ComscoreConnectorAdapter.web.ts
@@ -16,6 +16,7 @@ export class ComscoreConnectorAdapter {
             player,
             new ContentMetadata(ComscoreMetadata),
             new AdMetadata(),
+            ComscoreConfig.usagePropertiesAutoUpdateMode
         );
     }
 

--- a/comscore/src/internal/web/ComscoreAPI.ts
+++ b/comscore/src/internal/web/ComscoreAPI.ts
@@ -281,10 +281,11 @@ export class ComscoreAPI {
      * @param position
      */
     markPosition(position: number) {
+        const positionFloor = Math.floor(position)
         if (this.isDvr) {
-            this.startFromDvrWindowOffset(position);
+            this.startFromDvrWindowOffset(positionFloor);
         } else {
-            this.startFromPosition(position);
+            this.startFromPosition(positionFloor);
         }
     }
 

--- a/comscore/src/internal/web/ComscoreAPI.ts
+++ b/comscore/src/internal/web/ComscoreAPI.ts
@@ -50,6 +50,7 @@ export class ComscoreAPI {
      * @param projectId If Comscore provided you with an Project ID for your implementation, Comscore API: sa.setProjectId( "1234567890" )
      * @param playerName If Comscore instructed you to identify your players by name and version, Comscore API: sa.setMediaPlayerName( "My Player" )
      * @param playerVersion If Comscore instructed you to identify your players by name and version, Comscore API: sa.setMediaPlayerVersion( "1.2.3-a5f72c" )
+     * @param usagePropertiesAutoUpdateMode Indicates whether usage should be tracked when in foreground only, when back- and foreground or never, Comscore API: analytics.configuration.setUsagePropertiesAutoUpdateMode(0)
      */
     constructor(
         publisherId: string,
@@ -57,6 +58,7 @@ export class ComscoreAPI {
         projectId: string,
         playerName: string,
         playerVersion: string,
+        usagePropertiesAutoUpdateMode: string | undefined,
         skeleton: CustomSkeletonAPI | undefined
     ) {
         if (!publisherId) {
@@ -65,7 +67,7 @@ export class ComscoreAPI {
         // analytics = (window as any).ns_.analytics;
 
 
-        this.setupLibrary(publisherId);
+        this.setupLibrary(publisherId, usagePropertiesAutoUpdateMode);
         this.setStreamingAnalytics(
             implementationId,
             projectId,
@@ -78,10 +80,12 @@ export class ComscoreAPI {
      * setups library
      * see Comscore_Library-JavaScript-Implementation_Guide-International.pdf
      * @param {String} publisherId  Publisher ID value. The Publisher ID is often also referred to as the Client ID or c2 value.
+     * @param {String} usagePropertiesAutoUpdateMode Indicates whether usage should be tracked when in foreground only, when back- and foreground or never.
      */
-    setupLibrary(publisherId: string) {
+    setupLibrary(publisherId: string, usagePropertiesAutoUpdateMode: string) {
         this.setPlatformAPI();
         this.configurePublisher(publisherId);
+        this.configureUsagePropertiesAutoUpdateMode(usagePropertiesAutoUpdateMode);
         this.startsLibrary();
     }
 
@@ -114,6 +118,36 @@ export class ComscoreAPI {
         });
         analytics.configuration.addClient(config);
         logDebug('API - configurePublisher ', config);
+    }
+
+    /**
+     * Configures the application tracking to send usage data when the app is in foreground only, in back- and foreground or never.
+     * 
+     * @param mode 
+     */
+    configureUsagePropertiesAutoUpdateMode(mode: string) {
+        logDebug('API - setUsagePropertiesAutoUpdateMode to', mode);
+        switch (mode) {
+            case "foregroundOnly":
+                analytics.configuration.setUsagePropertiesAutoUpdateMode(
+                    analytics.configuration.UsagePropertiesAutoUpdateMode.FOREGROUND_ONLY
+                );
+                break;
+            case "foregroundAndBackground":
+                analytics.configuration.setUsagePropertiesAutoUpdateMode(
+                    analytics.configuration.UsagePropertiesAutoUpdateMode.FOREGROUND_AND_BACKGROUND
+                );
+                break;
+            case "disabled":
+                analytics.configuration.setUsagePropertiesAutoUpdateMode(
+                    analytics.configuration.UsagePropertiesAutoUpdateMode.DISABLED
+                );
+                break;
+            default:
+                analytics.configuration.setUsagePropertiesAutoUpdateMode(
+                    analytics.configuration.UsagePropertiesAutoUpdateMode.FOREGROUND_ONLY
+                );
+        }
     }
 
     /**

--- a/comscore/src/internal/web/ComscoreTheo.ts
+++ b/comscore/src/internal/web/ComscoreTheo.ts
@@ -37,6 +37,7 @@ export class ComscoreTheo extends TheoBase {
      * @param player THEOplayer instance
      * @param contentMetada content metadata
      * @param adMetadata ad metadata
+     * @param usagePropertiesAutoUpdateMode Indicates whether usage should be tracked when in foreground only, when back- and foreground or never, Comscore API: analytics.configuration.setUsagePropertiesAutoUpdateMode(0)
      * @param implementationId If Comscore provided you with an Implementation ID for your implementation, Comscore API: sa.setImplementationId( "1234567890" )
      * @param projectId If Comscore provided you with a Project ID for your implementation, Comscore API: sa.setProjectId( "1234567890" )
      * @param playerName If Comscore instructed you to identify your players by name and version, Comscore API: sa.setMediaPlayerName( "My Player" )
@@ -48,6 +49,7 @@ export class ComscoreTheo extends TheoBase {
         player: THEOplayer,
         contentMetada: ContentMetadata,
         adMetadata: AdMetadata,
+        usagePropertiesAutoUpdateMode: string = null,
         implementationId: string = null,
         projectId: string = null,
         playerName: string = null,
@@ -67,6 +69,7 @@ export class ComscoreTheo extends TheoBase {
             projectId,
             playerName,
             playerVersion,
+            usagePropertiesAutoUpdateMode,
             skeleton
         );
         this.bindListeners();


### PR DESCRIPTION
Making usagePropertiesAutoUpdateMode configurable for iOS depends on changes in https://github.com/THEOplayer/iOS-Connector/pull/25. Necessary changes in this repository are moved to a separate PR (https://github.com/THEOplayer/react-native-theoplayer-analytics/pull/127).