### PR TITLE
Bugfix/adobe web duration

### DIFF
--- a/adobe/CHANGELOG.md
+++ b/adobe/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue on Web where an asset with a pre-roll ad would report an invalid media duration.
+
+### Added
+
+- Added `debug` flag for extra logging.
+
 ## [1.4.0] - 2024-04-10
 
 ### Added

--- a/adobe/example/ios/Podfile
+++ b/adobe/example/ios/Podfile
@@ -1,22 +1,62 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
+platform :ios, min_ios_version_supported
 prepare_react_native_project!
 
-target 'TheoplayerAdobeExample' do
-  platform :ios, min_ios_version_supported
-  config = use_native_modules!
-  use_react_native!(:path => config[:reactNativePath])
-  pod 'THEOplayerSDK-basic', :path => './TheoSDK'
+# If you are using a `react-native-flipper` your iOS build will fail when `NO_FLIPPER=1` is set.
+# because `react-native-flipper` depends on (FlipperKit,...) that will be excluded
+#
+# To fix this you can also exclude `react-native-flipper` using a `react-native.config.js`
+# ```js
+# module.exports = {
+#   dependencies: {
+#     ...(process.env.NO_FLIPPER ? { 'react-native-flipper': { platforms: { ios: null } } } : {}),
+# ```
+flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
+
+linkage = ENV['USE_FRAMEWORKS']
+if linkage != nil
+  Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
+  use_frameworks! :linkage => linkage.to_sym
 end
 
-# target 'TheoplayerAdobeExample-tvOS' do
-#   platform :tvos, min_tvos_version_supported
-#   config = use_native_modules!
-#   use_react_native!(:path => config[:reactNativePath])
-#   pod 'THEOplayerSDK-basic', :path => './TheoSDK'
-# end
+target 'TheoplayerAdobeExample' do
+  platform :ios, '13.4'
 
-post_install do |installer|
-  __apply_Xcode_12_5_M1_post_install_workaround(installer)
+  config = use_native_modules!
+
+  # Flags change depending on the env values.
+  flags = get_default_flags()
+
+  use_react_native!(
+    :path => config[:reactNativePath],
+    # Hermes is now enabled by default. Disable by setting this flag to false.
+    # Upcoming versions of React Native may rely on get_default_flags(), but
+    # we make it explicit here to aid in the React Native upgrade process.
+    :hermes_enabled => flags[:hermes_enabled],
+    :fabric_enabled => flags[:fabric_enabled],
+    # Enables Flipper.
+    #
+    # Note that if you have use_frameworks! enabled, Flipper will not work and
+    # you should disable the next line.
+    :flipper_configuration => flipper_config,
+    # An absolute path to your application root.
+    :app_path => "#{Pod::Config.instance.installation_root}/.."
+  )
+
+  target 'TheoplayerAdobeExampleTests' do
+    inherit! :complete
+    # Pods for testing
+  end
+
+  post_install do |installer|
+    react_native_post_install(
+      installer,
+      # Set `mac_catalyst_enabled` to `true` in order to apply patches
+      # necessary for Mac Catalyst builds
+      :mac_catalyst_enabled => false
+    )
+    __apply_Xcode_12_5_M1_post_install_workaround(installer)
+  end
 end

--- a/adobe/example/react-native-theoplayer.json
+++ b/adobe/example/react-native-theoplayer.json
@@ -1,0 +1,7 @@
+{
+	"ios": {
+		"features": [
+			"GOOGLE_IMA"
+		]
+	}
+}

--- a/adobe/example/src/App.tsx
+++ b/adobe/example/src/App.tsx
@@ -36,7 +36,8 @@ const sid = "<suite_id>" // "<Report Suite ID>";
 const trackingUrl = "<tracking_url>" // "<Tracking Server URL>";
 
 const App = () => {
-  const [, initAdobe] = useAdobe(uri, ecid, sid, trackingUrl);
+  const [, initAdobe] = useAdobe(uri, ecid, sid, trackingUrl, undefined,
+    undefined, true);
   const [player, setPlayer] = useState<THEOplayer | undefined>();
 
   const onPlayerReady = useCallback((player: THEOplayer) => {

--- a/adobe/example/src/custom/sources.json
+++ b/adobe/example/src/custom/sources.json
@@ -84,6 +84,7 @@
     "name": "HLS - CSAI - Google IMA pre-roll",
     "os": [
       "ios",
+      "android",
       "web"
     ],
     "source": {

--- a/adobe/example/src/custom/sources.json
+++ b/adobe/example/src/custom/sources.json
@@ -47,5 +47,37 @@
         "releaseYear": 1997
       }
     }
+  },
+  {
+    "name": "DASH - CSAI - Google IMA pre-roll",
+    "os": [
+      "android",
+      "web"
+    ],
+    "source": {
+      "sources": [
+        {
+          "src": "https://cdn.theoplayer.com/video/dash/bbb_30fps/bbb_with_multiple_tiled_thumbnails.mpd",
+          "type": "application/dash+xml"
+        }
+      ],
+      "ads": [
+        {
+          "integration": "google-ima",
+          "sources": {
+            "src": "https://cdn.theoplayer.com/demos/ads/vast/dfp-preroll-no-skip.xml"
+          }
+        }
+      ],
+      "poster": "https://cdn.theoplayer.com/video/big_buck_bunny/poster.jpg",
+      "metadata": {
+        "title": "Big Buck Bunny",
+        "subtitle": "DASH - Thumbnails in manifest",
+        "album": "React-Native THEOplayer demos",
+        "mediaUri": "https://theoplayer.com",
+        "displayIconUri": "https://cdn.theoplayer.com/video/big_buck_bunny/poster.jpg",
+        "artist": "THEOplayer"
+      }
+    }
   }
 ]

--- a/adobe/example/src/custom/sources.json
+++ b/adobe/example/src/custom/sources.json
@@ -79,5 +79,34 @@
         "artist": "THEOplayer"
       }
     }
+  },
+  {
+    "name": "HLS - CSAI - Google IMA pre-roll",
+    "os": [
+      "ios",
+      "web"
+    ],
+    "source": {
+      "sources": [
+        {
+          "src": "https://cdn.theoplayer.com/video/elephants-dream/playlistCorrectionENG.m3u8",
+          "type": "application/x-mpegurl"
+        }
+      ],
+      "ads": [
+        {
+          "integration": "google-ima",
+          "sources": "https://cdn.theoplayer.com/demos/ads/vast/dfp-preroll-no-skip.xml"
+        }
+      ],
+      "poster": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-1200x1200.png",
+      "metadata": {
+        "title": "Elephants Dream with Preroll",
+        "subtitle": "Elephants Dream with Preroll Subtitle",
+        "album": "Elephants Album",
+        "displayIconUri": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-200x200.png",
+        "artist": "The Dream"
+      }
+    }
   }
 ]

--- a/adobe/src/api/AdobeConnector.ts
+++ b/adobe/src/api/AdobeConnector.ts
@@ -6,8 +6,9 @@ export class AdobeConnector {
 
   private connectorAdapter: AdobeConnectorAdapter
 
-  constructor(player: THEOplayer, uri: string, ecid: string, sid: string, trackingUrl: string, metadata?: AdobeMetaData, userAgent?: string) {
-    this.connectorAdapter = new AdobeConnectorAdapter(player, uri, ecid, sid, trackingUrl, metadata, userAgent);
+  constructor(player: THEOplayer, uri: string, ecid: string, sid: string, trackingUrl: string, metadata?: AdobeMetaData,
+              userAgent?: string, useDebug?: boolean) {
+    this.connectorAdapter = new AdobeConnectorAdapter(player, uri, ecid, sid, trackingUrl, metadata, userAgent, useDebug);
   }
 
   /**
@@ -23,6 +24,14 @@ export class AdobeConnector {
    */
   setError(metadata: AdobeMetaData): void {
     this.connectorAdapter.setError(metadata);
+  }
+
+  /**
+   * Set debug flag.
+   * @param debug whether to write debug info or not.
+   */
+  setDebug(debug: boolean) {
+    this.connectorAdapter.setDebug(debug);
   }
 
   /**

--- a/adobe/src/api/hooks/useAdobe.ts
+++ b/adobe/src/api/hooks/useAdobe.ts
@@ -10,37 +10,37 @@ export function useAdobe(uri: string,
                          metadata?: AdobeMetaData,
                          userAgent?: string,
                          useDebug?: boolean)
-    : [RefObject<AdobeConnector | undefined>, (player: THEOplayer | undefined) => void] {
-    const connector = useRef<AdobeConnector | undefined>();
-    const theoPlayer = useRef<THEOplayer | undefined>();
+  : [RefObject<AdobeConnector | undefined>, (player: THEOplayer | undefined) => void] {
+  const connector = useRef<AdobeConnector | undefined>();
+  const theoPlayer = useRef<THEOplayer | undefined>();
 
-    const initialize = (player: THEOplayer | undefined) => {
-        // Optionally destroy existent connector
-        onDestroy();
+  const initialize = (player: THEOplayer | undefined) => {
+    // Optionally destroy existent connector
+    onDestroy();
 
-        theoPlayer.current = player;
-        if (player) {
-            connector.current = new AdobeConnector(player, uri, ecid, sid, trackingUrl, metadata, userAgent, useDebug);
-            player.addEventListener(PlayerEventType.DESTROY, onDestroy);
-        } else {
-            throw new Error("Invalid THEOplayer instance");
-        }
+    theoPlayer.current = player;
+    if (player) {
+      connector.current = new AdobeConnector(player, uri, ecid, sid, trackingUrl, metadata, userAgent, useDebug);
+      player.addEventListener(PlayerEventType.DESTROY, onDestroy);
+    } else {
+      throw new Error("Invalid THEOplayer instance");
     }
+  }
 
-    const onDestroy = () => {
-        if (connector.current) {
-            if (!theoPlayer.current) {
-                throw new Error("Invalid THEOplayer instance");
-            }
-            theoPlayer.current.removeEventListener(PlayerEventType.DESTROY, onDestroy);
-            connector.current.destroy();
-            connector.current = undefined;
-        }
+  const onDestroy = () => {
+    if (connector.current) {
+      if (!theoPlayer.current) {
+        throw new Error("Invalid THEOplayer instance");
+      }
+      theoPlayer.current.removeEventListener(PlayerEventType.DESTROY, onDestroy);
+      connector.current.destroy();
+      connector.current = undefined;
     }
+  }
 
-    useEffect(() => {
-        return onDestroy;
-    }, []);
+  useEffect(() => {
+    return onDestroy;
+  }, []);
 
-    return [connector, initialize];
+  return [connector, initialize];
 }

--- a/adobe/src/api/hooks/useAdobe.ts
+++ b/adobe/src/api/hooks/useAdobe.ts
@@ -8,7 +8,8 @@ export function useAdobe(uri: string,
                          sid: string,
                          trackingUrl: string,
                          metadata?: AdobeMetaData,
-                         userAgent?: string)
+                         userAgent?: string,
+                         useDebug?: boolean)
     : [RefObject<AdobeConnector | undefined>, (player: THEOplayer | undefined) => void] {
     const connector = useRef<AdobeConnector | undefined>();
     const theoPlayer = useRef<THEOplayer | undefined>();
@@ -19,7 +20,7 @@ export function useAdobe(uri: string,
 
         theoPlayer.current = player;
         if (player) {
-            connector.current = new AdobeConnector(player, uri, ecid, sid, trackingUrl, metadata, userAgent);
+            connector.current = new AdobeConnector(player, uri, ecid, sid, trackingUrl, metadata, userAgent, useDebug);
             player.addEventListener(PlayerEventType.DESTROY, onDestroy);
         } else {
             throw new Error("Invalid THEOplayer instance");

--- a/adobe/src/internal/AdobeConnectorAdapter.ts
+++ b/adobe/src/internal/AdobeConnectorAdapter.ts
@@ -450,6 +450,7 @@ export class AdobeConnectorAdapter {
   reset(): void {
     this.adBreakPodIndex = 0;
     this.adPodPosition = 1;
+    this.isPlayingAd = false;
     this.sessionId = '';
     this.sessionInProgress = false;
     clearInterval(this.pingInterval);

--- a/adobe/src/internal/AdobeConnectorAdapter.ts
+++ b/adobe/src/internal/AdobeConnectorAdapter.ts
@@ -313,7 +313,7 @@ export class AdobeConnectorAdapter {
 
     const response = await this.sendRequest(this.uri, body);
 
-    if (response.status !== 201) {
+    if (response?.status !== 201) {
       console.error(TAG, 'Error during session creation', response);
       return;
     }
@@ -365,7 +365,7 @@ export class AdobeConnectorAdapter {
     const url = `${ this.uri }/${ this.sessionId }/events`;
     const response = await this.sendRequest(url, body);
 
-    if (response.status === 404 || response.status === 410) {
+    if (response?.status === 404 || response?.status === 410) {
       // Faulty session id, store in queue and remake session
       this.eventQueue.push(body);
       if (this.sessionId !== '' && this.sessionInProgress) {
@@ -410,17 +410,22 @@ export class AdobeConnectorAdapter {
     }
   }
 
-  private async sendRequest(url: string, body: AdobeEventRequestBody): Promise<Response> {
-    return await fetch(url, {
-      method: 'POST',
-      body: JSON.stringify(body),
-      headers: {
-        'Content-Type': 'application/json',
+  private async sendRequest(url: string, body: AdobeEventRequestBody): Promise<Response | undefined> {
+    try {
+      return await fetch(url, {
+        method: 'POST',
+        body: JSON.stringify(body),
+        headers: {
+          'Content-Type': 'application/json',
 
-        // Override User-Agent with provided value.
-        ...(this.customUserAgent && {'User-Agent': this.customUserAgent})
-      }
-    })
+          // Override User-Agent with provided value.
+          ...(this.customUserAgent && {'User-Agent': this.customUserAgent})
+        }
+      });
+    } catch (e) {
+      console.error(TAG, "Failed to send request");
+      return undefined;
+    }
   }
 
   /**

--- a/adobe/src/internal/AdobeConnectorAdapter.ts
+++ b/adobe/src/internal/AdobeConnectorAdapter.ts
@@ -13,7 +13,7 @@ import { AdEventType, MediaTrackEventType, PlayerEventType, TextTrackEventType }
 import type { AdobeEventRequestBody, AdobeMetaData, ContentType } from "./Types";
 import { AdobeEventTypes } from "./Types";
 import { calculateAdBeginMetadata, calculateAdBreakBeginMetadata, calculateChapterStartMetadata } from "../utils/Utils";
-  import { NativeModules, Platform } from "react-native";
+import { NativeModules, Platform } from "react-native";
 import DeviceInfo from "react-native-device-info";
 
 const TAG = "AdobeConnector";
@@ -70,12 +70,12 @@ export class AdobeConnectorAdapter {
   constructor(player: THEOplayer, uri: string, ecid: string, sid: string, trackingUrl: string, metadata?: AdobeMetaData,
               userAgent?: string, debug = false) {
     this.player = player
-    this.uri = `https://${ uri }/api/v1/sessions`;
+    this.uri = `https://${uri}/api/v1/sessions`;
     this.ecid = ecid;
     this.sid = sid;
     this.debug = debug;
     this.trackingUrl = trackingUrl;
-    this.customMetadata = { ...this.customMetadata, ...metadata };
+    this.customMetadata = {...this.customMetadata, ...metadata};
     this.customUserAgent = userAgent || this.buildUserAgent();
 
     this.addEventListeners();
@@ -88,7 +88,7 @@ export class AdobeConnectorAdapter {
   }
 
   updateMetadata(metadata: AdobeMetaData): void {
-    this.customMetadata = { ...this.customMetadata, ...metadata };
+    this.customMetadata = {...this.customMetadata, ...metadata};
   }
 
   setError(metadata: AdobeMetaData): void {
@@ -229,7 +229,7 @@ export class AdobeConnectorAdapter {
         const adBreak = event.ad as AdBreak;
         const metadata = calculateAdBreakBeginMetadata(adBreak, this.adBreakPodIndex);
         void this.sendEventRequest(AdobeEventTypes.AD_BREAK_START, metadata);
-        if (( metadata.params as any )[ "media.ad.podIndex" ] > this.adBreakPodIndex) { // TODO fix!
+        if ((metadata.params as any)["media.ad.podIndex"] > this.adBreakPodIndex) { // TODO fix!
           this.adBreakPodIndex++;
         }
         break;
@@ -343,10 +343,10 @@ export class AdobeConnectorAdapter {
       console.error(TAG, 'No location header present');
       return;
     }
-    this.sessionId = splitResponseUrl[ splitResponseUrl.length - 1 ];
+    this.sessionId = splitResponseUrl[splitResponseUrl.length - 1];
 
     if (this.eventQueue.length !== 0) {
-      const url = `${ this.uri }/${ this.sessionId }/events`;
+      const url = `${this.uri}/${this.sessionId}/events`;
       for (const body of this.eventQueue) {
         await this.sendRequest(url, body); // TODO another fallback necessary on top?
       }
@@ -375,14 +375,14 @@ export class AdobeConnectorAdapter {
   }
 
   private async sendEventRequest(eventType: AdobeEventTypes, metadata?: AdobeEventRequestBody): Promise<void> {
-    const initialBody: AdobeEventRequestBody = { ...this.createBaseRequest(eventType), ...metadata};
+    const initialBody: AdobeEventRequestBody = {...this.createBaseRequest(eventType), ...metadata};
     const body = this.addCustomMetadata(eventType, initialBody);
     if (this.sessionId === '') {
       // Session hasn't started yet but no session id --> add to queue
       this.eventQueue.push(body);
       return;
     }
-    const url = `${ this.uri }/${ this.sessionId }/events`;
+    const url = `${this.uri}/${this.sessionId}/events`;
     const response = await this.sendRequest(url, body);
 
     if (response?.status === 404 || response?.status === 410) {

--- a/adobe/src/internal/AdobeConnectorAdapter.ts
+++ b/adobe/src/internal/AdobeConnectorAdapter.ts
@@ -289,7 +289,6 @@ export class AdobeConnectorAdapter {
     if (this.sessionInProgress || !this.player.source || !isValidDuration(mediaLength)) {
       return;
     }
-    this.sessionInProgress = true;
     const initialBody = this.createBaseRequest(AdobeEventTypes.SESSION_START);
     let friendlyName = {};
     if (this.player.source.metadata?.title) {
@@ -317,6 +316,7 @@ export class AdobeConnectorAdapter {
       console.error(TAG, 'Error during session creation', response);
       return;
     }
+    this.sessionInProgress = true;
 
     const splitResponseUrl = response.headers.get('location')?.split('/sessions/');
     if (splitResponseUrl === undefined) {

--- a/adobe/src/internal/AdobeConnectorAdapter.ts
+++ b/adobe/src/internal/AdobeConnectorAdapter.ts
@@ -248,10 +248,9 @@ export class AdobeConnectorAdapter {
 
   private async maybeEndSession(): Promise<void> {
     if (this.sessionId !== '') {
-      return this.sendEventRequest(AdobeEventTypes.SESSION_END).then(() => {
-        this.reset();
-      });
+      await this.sendEventRequest(AdobeEventTypes.SESSION_END);
     }
+    this.reset();
     return Promise.resolve();
   }
 

--- a/adobe/src/internal/AdobeConnectorAdapter.ts
+++ b/adobe/src/internal/AdobeConnectorAdapter.ts
@@ -271,7 +271,8 @@ export class AdobeConnectorAdapter {
   }
 
   private async startSession(mediaLengthMsec?: number): Promise<void> {
-    if (this.sessionInProgress || !this.player.source) {
+    const mediaLength = this.getContentLength(mediaLengthMsec);
+    if (this.sessionInProgress || !this.player.source || !isValidDuration(mediaLength)) {
       return;
     }
     this.sessionInProgress = true;
@@ -288,7 +289,7 @@ export class AdobeConnectorAdapter {
       "media.channel": "N/A",
       "media.contentType": this.getContentType(),
       "media.id": "N/A",
-      "media.length": this.getContentLength(mediaLengthMsec),
+      "media.length": mediaLength,
       "media.playerName": "THEOplayer", // TODO make distinctions between platforms?
       "visitor.marketingCloudOrgId": this.ecid,
       ...friendlyName,
@@ -441,4 +442,8 @@ export class AdobeConnectorAdapter {
     await this.maybeEndSession();
     this.removeEventListeners();
   }
+}
+
+function isValidDuration(v: number | undefined): boolean {
+  return v !== undefined && !Number.isNaN(v);
 }

--- a/adobe/src/internal/AdobeConnectorAdapter.ts
+++ b/adobe/src/internal/AdobeConnectorAdapter.ts
@@ -16,6 +16,7 @@ import { calculateAdBeginMetadata, calculateAdBreakBeginMetadata, calculateChapt
   import { NativeModules, Platform } from "react-native";
 import DeviceInfo from "react-native-device-info";
 
+const TAG = "AdobeConnector";
 const CONTENT_PING_INTERVAL = 10000;
 const AD_PING_INTERVAL = 1000;
 const USER_AGENT_PREFIX = 'Mozilla/5.0';
@@ -313,13 +314,13 @@ export class AdobeConnectorAdapter {
     const response = await this.sendRequest(this.uri, body);
 
     if (response.status !== 201) {
-      console.error('ERROR DURING SESSION CREATION', response);
+      console.error(TAG, 'Error during session creation', response);
       return;
     }
 
     const splitResponseUrl = response.headers.get('location')?.split('/sessions/');
     if (splitResponseUrl === undefined) {
-      console.error('NO LOCATION HEADER PRESENT');
+      console.error(TAG, 'No location header present');
       return;
     }
     this.sessionId = splitResponseUrl[ splitResponseUrl.length - 1 ];

--- a/adobe/src/internal/AdobeConnectorAdapter.ts
+++ b/adobe/src/internal/AdobeConnectorAdapter.ts
@@ -304,7 +304,10 @@ export class AdobeConnectorAdapter {
     const mediaLength = this.getContentLength(mediaLengthMsec);
     this.logDebug(`maybeStartSession - mediaLength: ${mediaLength}`);
     if (this.sessionInProgress || !this.player.source || !isValidDuration(mediaLength)) {
-      this.logDebug(`maybeStartSession - sessionInProgress: ${this.sessionInProgress}, hasSource: ${this.player.source !== undefined}, isValidDuration: ${isValidDuration(mediaLength)}`);
+      this.logDebug('maybeStartSession - NOT started',
+        `sessionInProgress: ${this.sessionInProgress}`,
+        `hasSource: ${this.player.source !== undefined}`,
+        `isValidDuration: ${isValidDuration(mediaLength)}`);
       return;
     }
     const initialBody = this.createBaseRequest(AdobeEventTypes.SESSION_START);
@@ -343,6 +346,7 @@ export class AdobeConnectorAdapter {
       return;
     }
     this.sessionId = splitResponseUrl[splitResponseUrl.length - 1];
+    this.logDebug('maybeStartSession - STARTED', `sessionId: ${this.sessionId}`);
 
     if (this.eventQueue.length !== 0) {
       const url = `${this.uri}/${this.sessionId}/events`;

--- a/adobe/src/internal/AdobeConnectorAdapter.ts
+++ b/adobe/src/internal/AdobeConnectorAdapter.ts
@@ -170,11 +170,10 @@ export class AdobeConnectorAdapter {
     void this.sendEventRequest(AdobeEventTypes.BUFFER_START);
   }
 
-  private onEnded = () => {
+  private onEnded = async () => {
     this.logDebug('onEnded');
-    this.sendEventRequest(AdobeEventTypes.SESSION_COMPLETE).then(() => {
-      this.reset();
-    });
+    await this.sendEventRequest(AdobeEventTypes.SESSION_COMPLETE);
+    this.reset();
   }
 
   private onSourceChange = () => {


### PR DESCRIPTION
Fixed media duration on web for sources with a pre-roll asset.

This issue comes from am inconistency between platforms Web and Android & iOS.

On web:
- the `loadedmetadata` is sent before the pre-roll; at this point the `duration` is still NaN for DASH, but not for HLS.
- when content starts, another `loadedmetadata` is sent with correct content `duration`.

On Android:
- the `loadedmetadata` is only sent after the pre-roll

On iOS:
- the `loadedmetadata` is sent before the pre-roll; at this point the `duration` is the duration of the ad.
- when content starts, another `loadedmetadata` is sent with correct content `duration`.